### PR TITLE
SOAP backchannel logout for SAML protocol (#9548)

### DIFF
--- a/apps/admin-ui/public/resources/en/clients-help.json
+++ b/apps/admin-ui/public/resources/en/clients-help.json
@@ -110,6 +110,7 @@
   "assertionConsumerServiceRedirectBindingURL": "SAML Redirect Binding URL for the client's assertion consumer service (login responses). You can leave this blank if you do not have a URL for this binding.",
   "logoutServicePostBindingURL": "SAML POST Binding URL for the client's single logout service. You can leave this blank if you are using a different binding",
   "logoutServiceRedirectBindingURL": "SAML Redirect Binding URL for the client's single logout service. You can leave this blank if you are using a different binding.",
+  "logoutServiceSoapBindingUrl": "SAML SOAP Binding URL for the client's single logout service. You can leave this blank if you are using a different binding.",
   "logoutServiceArtifactBindingUrl": "SAML ARTIFACT Binding URL for the client's single logout service. You can leave this blank if you are using a different binding.",
   "artifactBindingUrl": "URL to send the HTTP ARTIFACT messages to. You can leave this blank if you are using a different binding. This value should be set when forcing ARTIFACT binding together with IdP initiated login.",
   "frontchannelLogout": "When true, logout requires a browser redirect to client. When false, server performs a background invocation for logout.",

--- a/apps/admin-ui/public/resources/en/clients.json
+++ b/apps/admin-ui/public/resources/en/clients.json
@@ -477,6 +477,7 @@
   "assertionConsumerServiceRedirectBindingURL": "Assertion Consumer Service Redirect Binding URL",
   "logoutServicePostBindingURL": "Logout Service POST Binding URL",
   "logoutServiceRedirectBindingURL": "Logout Service Redirect Binding URL",
+  "logoutServiceSoapBindingUrl": "Logout Service SOAP Binding URL",
   "logoutServiceArtifactBindingUrl": "Logout Service ARTIFACT Binding URL",
   "artifactBindingUrl": "Artifact Binding URL",
   "artifactResolutionService": "Artifact Resolution Service",

--- a/apps/admin-ui/src/clients/advanced/FineGrainSamlEndpointConfig.tsx
+++ b/apps/admin-ui/src/clients/advanced/FineGrainSamlEndpointConfig.tsx
@@ -86,6 +86,22 @@ export const FineGrainSamlEndpointConfig = ({
         />
       </FormGroup>
       <FormGroup
+        label={t("logoutServiceSoapBindingUrl")}
+        fieldId="logoutServiceSoapBindingUrl"
+        labelIcon={
+          <HelpItem
+            helpText="clients-help:logoutServiceSoapBindingUrl"
+            fieldLabelId="clients:logoutServiceSoapBindingUrl"
+          />
+        }
+      >
+        <KeycloakTextInput
+          id="logoutServiceSoapBindingUrl"
+          type="url"
+          {...register("attributes.saml_single_logout_service_url_soap")}
+        />
+      </FormGroup>
+      <FormGroup
         label={t("logoutServiceArtifactBindingUrl")}
         fieldId="logoutServiceArtifactBindingUrl"
         labelIcon={

--- a/apps/admin-ui/src/clients/import/ImportForm.tsx
+++ b/apps/admin-ui/src/clients/import/ImportForm.tsx
@@ -32,7 +32,7 @@ import { FormFields } from "../ClientDetails";
 import { toClient } from "../routes/Client";
 import { toClients } from "../routes/Clients";
 
-const isXml = (text: string) => text.startsWith("<");
+const isXml = (text: string) => text.trim().startsWith("<");
 
 export default function ImportForm() {
   const { t } = useTranslation("clients");


### PR DESCRIPTION
## Motivation
Add SAML SOAP backchannel logout URL on SAML client (#9548)

## Brief Description
A new URL is needed in the SAML client parameters to be able to execute a SOAP Backchannel logout request from Keycloak to the client during single logout process.

## Verification Steps
Open the SAML client, go to the tab "Advanced".
In the "Fine Grain SAML Endpoint Configuration" section, the field "Logout Service SOAP Binding URL" should be displayed.

## Checklist:

- [X] Code has been tested locally by PR requester
- [x] User-visible strings are using the react-i18next framework (useTranslation)
- [X] Help has been implemented
- [-] axe report has been run and resulting a11y issues have been resolved
- [-] Unit tests have been created/updated

## Additional Notes
n.a.
